### PR TITLE
feat: add you.com search provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,21 @@ All settings live in `config.toml`. Environment variables override for secrets:
 | `LLM_MODEL` | `[llm] model` | No |
 | `MEMORY_DB_PATH` | `[memory] db_path` | No |
 | `LOG_DIR` | `[observe] log_dir` | No |
+| `WEB_SEARCH_PROVIDER` | Web search backend (`duckduckgo` or `youcom`) | No |
+| `YOUCOM_SEARCH_API_KEY` | API key for You.com web search (`X-API-Key`) | No |
 
 See `config.toml` for all available settings and their defaults.
+
+### Web search provider setup
+
+By default, `web_search` uses DuckDuckGo. To use You.com Search API:
+
+```bash
+export WEB_SEARCH_PROVIDER=youcom
+export YOUCOM_SEARCH_API_KEY=your_api_key_here
+```
+
+Fallback behavior: if You.com is selected but the API key is missing (or the API request fails), Luna falls back to DuckDuckGo and annotates the tool result.
 
 ## Components
 
@@ -191,7 +204,7 @@ Built-in tools that don't require external MCP servers:
 | `write_file` | Write or append to files, creates parent directories |
 | `list_directory` | List files/directories, optional recursion with depth limits |
 | `web_fetch` | Fetch a URL and convert HTML to markdown via html2text |
-| `web_search` | Search the web via DuckDuckGo, returns structured results |
+| `web_search` | Search the web via DuckDuckGo (default) or You.com (`WEB_SEARCH_PROVIDER=youcom`) |
 | `delegate` | Hand off a self-contained subtask to a sub-agent with its own tool loop |
 | `code_task` | Delegate a coding task to a sub-agent with a write-run-fix loop |
 | `summarize_paper` | Fetch and summarize an arXiv paper |

--- a/luna/tools.py
+++ b/luna/tools.py
@@ -874,17 +874,77 @@ async def _tool_web_search(args: dict, context: str = "", llm=None, root=None, *
     if not query:
         return "Error: 'query' is required"
 
-    try:
-        from ddgs import DDGS
-    except ImportError:
-        return "Error: duckduckgo-search package not installed. Run: pip install duckduckgo-search"
+    provider = os.getenv("WEB_SEARCH_PROVIDER", "duckduckgo").strip().lower()
+    youcom_key = os.getenv("YOUCOM_SEARCH_API_KEY")
 
-    try:
-        results = await asyncio.to_thread(
-            lambda: list(DDGS().text(query, max_results=max_results))
-        )
-    except Exception as e:
-        return f"Error searching: {e}"
+    async def _search_duckduckgo() -> tuple[list[dict[str, str]], str | None]:
+        try:
+            from ddgs import DDGS
+        except ImportError:
+            return [], "Error: duckduckgo-search package not installed. Run: pip install duckduckgo-search"
+
+        try:
+            results = await asyncio.to_thread(
+                lambda: list(DDGS().text(query, max_results=max_results))
+            )
+        except Exception as e:
+            return [], f"Error searching DuckDuckGo: {e}"
+
+        normalized = [
+            {
+                "title": r.get("title", ""),
+                "url": r.get("href", ""),
+                "snippet": r.get("body", ""),
+            }
+            for r in results
+        ]
+        return normalized, None
+
+    async def _search_youcom(api_key: str) -> tuple[list[dict[str, str]], str | None]:
+        import httpx
+
+        url = "https://api.ydc-index.io/search"
+        headers = {"X-API-Key": api_key}
+        params = {"query": query, "num_web_results": max_results}
+
+        try:
+            async with httpx.AsyncClient(timeout=20) as client:
+                response = await client.get(url, headers=headers, params=params)
+                response.raise_for_status()
+                payload = response.json()
+        except Exception as e:
+            return [], f"Error searching You.com: {e}"
+
+        # Support multiple payload shapes for compatibility across API versions.
+        candidates = payload.get("hits") or payload.get("results") or payload.get("items") or []
+        normalized: list[dict[str, str]] = []
+        for item in candidates:
+            title = item.get("title") or item.get("name") or ""
+            url_value = item.get("url") or item.get("link") or ""
+            snippets = item.get("snippets") or []
+            snippet = " ".join(snippets) if isinstance(snippets, list) else str(snippets)
+            if not snippet:
+                snippet = item.get("description") or item.get("body") or ""
+            normalized.append({"title": title, "url": url_value, "snippet": snippet})
+
+        return normalized, None
+
+    notes: list[str] = []
+    if provider in {"you", "youcom", "you.com"}:
+        if not youcom_key:
+            notes.append("[NOTE: YOUCOM_SEARCH_API_KEY not set; falling back to DuckDuckGo.]")
+            results, error = await _search_duckduckgo()
+        else:
+            results, error = await _search_youcom(youcom_key)
+            if error:
+                notes.append(f"[NOTE: {error} Falling back to DuckDuckGo.]")
+                results, ddg_error = await _search_duckduckgo()
+                error = ddg_error
+    else:
+        results, error = await _search_duckduckgo()
+
+    if error and not results:
+        return error
 
     if not results:
         return "No results found."
@@ -892,11 +952,13 @@ async def _tool_web_search(args: dict, context: str = "", llm=None, root=None, *
     output_parts: list[str] = []
     for i, r in enumerate(results, 1):
         title = r.get("title", "")
-        href = r.get("href", "")
-        body = r.get("body", "")
+        href = r.get("url", "")
+        body = r.get("snippet", "")
         output_parts.append(f"{i}. **{title}**\n   {href}\n   {body}")
 
     output = "\n\n".join(output_parts)
+    if notes:
+        output = "\n".join(notes) + "\n\n" + output
     return await process_large_output(output, context or query, f"web_search_{query[:30]}", llm, root=root)
 
 


### PR DESCRIPTION
## Why this repo was selected\n- Small, active AI-agent runtime (**13 stars**, pushed today) where web search is a core native tool.\n- Existing  was DuckDuckGo-only, so adding an optional provider abstraction is a clean, high-value extension for agent intelligence.\n- Codebase is focused and maintainable, making review/acceptance likely.\n\n## What changed\n- Added provider selection for  via  ( default,  optional).\n- Added You.com Search API integration () using .\n- Normalized result formatting so both providers render consistently (, , ).\n- Added fallback behavior:\n  - If  but key is missing, falls back to DuckDuckGo with an explicit note.\n  - If You.com request fails, falls back to DuckDuckGo with an explicit note.\n- Updated README with env var setup and usage/fallback documentation.\n\n## Setup\n\n\nTo use default behavior, omit these and  continues to use DuckDuckGo.\n\n## Validation done\n-  ✅\n- Attempted full test run, but local environment could not install dependency  from index () so pytest could not be executed in this runner.\n\n## Why this helps agent intelligence\n- Lets maintainers/users choose a stronger commercial web index without removing free default behavior.\n- Improves reliability through graceful fallback, so agent workflows depending on web search degrade safely instead of hard failing.\n- Keeps the integration minimal and provider-agnostic for future extension.